### PR TITLE
docs: changes letter v in revent to c

### DIFF
--- a/contracts/BaseRouter.sol
+++ b/contracts/BaseRouter.sol
@@ -66,7 +66,7 @@ abstract contract BaseRouter {
 
     /**
      * @notice
-     *  Used to get the most revent vault for the token using the registry.
+     *  Used to get the most recent vault for the token using the registry.
      * @return An instance of a VaultAPI
      */
     function bestVault(address token) public view virtual returns (VaultAPI) {


### PR DESCRIPTION
## Description

Changes one letter in the description of bestVault() view function. 
Same description at BaseWrapper.sol#L38. 

Fixes # (issue)
typo
no issue

## Checklist

- [ ] I have run vyper and solidity linting
- [ ] I have run the tests on my machine
- [x] I have followed commitlint guidelines
- [x] I have rebased my changes to the latest version of the main branch

